### PR TITLE
Add rudimentary command-line interface

### DIFF
--- a/AppCLI.config
+++ b/AppCLI.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+    <runtime>
+        <gcAllowVeryLargeObjects enabled="true" />
+    </runtime>
+</configuration>

--- a/ProgramCLI.cs
+++ b/ProgramCLI.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Threading;
+using System.ComponentModel;
+using System.Windows.Media.Imaging;
+using Voxel_Fortress;
+
+namespace Voxel_Fortress_CLI
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                Console.WriteLine("Elevation map argument missing");
+                return;
+            }
+            string heightMapFileName = args[0];
+            if (!File.Exists(heightMapFileName))
+            {
+                Console.WriteLine("Elevation map file not found: {0}", heightMapFileName);
+                return;
+            }
+            heightMapFileName = Path.GetFullPath(heightMapFileName);
+            Console.WriteLine("Elevation map: {0}", heightMapFileName);
+            
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Color map argument missing");
+                return;
+            }
+            string colorMapFileName = args[1];
+            if (!File.Exists(colorMapFileName))
+            {
+                Console.WriteLine("Color map file not found: {0}", colorMapFileName);
+                return;
+            }
+            colorMapFileName = Path.GetFullPath(colorMapFileName);
+            Console.WriteLine("Color map: {0}", colorMapFileName);
+
+            MapMaker mapMaker = new MapMaker();
+            MapMaker.Images mapImages = new MapMaker.Images();
+
+            {
+                mapImages.imageFilename = heightMapFileName;
+                BitmapImage elevationMap = new BitmapImage(new Uri(heightMapFileName));
+                mapImages.elevationMap = MapMaker.ConvertBitmapImage(elevationMap);
+
+                mapImages.imageFilename = colorMapFileName;
+                BitmapImage colorMap = new BitmapImage(new Uri(colorMapFileName));
+                mapImages.colorMap = MapMaker.ConvertBitmapImage(colorMap);
+            }
+
+            exportMap(mapMaker, mapImages);
+        }
+
+        private static void exportMap(MapMaker mapMaker, MapMaker.Images mapImages)
+        {
+            ManualResetEvent done = new ManualResetEvent(false);
+
+            BackgroundWorker mapExportWorker = new BackgroundWorker();
+            mapExportWorker.WorkerReportsProgress = true;
+            mapExportWorker.DoWork += mapMaker.LoadMap;
+            mapExportWorker.ProgressChanged += (s, e) => {
+                Console.WriteLine("{0}\t{1}", e.ProgressPercentage, e.UserState as string);
+            };
+            mapExportWorker.RunWorkerCompleted += (s, e) => {
+                Console.WriteLine("Completed.");
+                done.Set();
+            };
+            mapExportWorker.RunWorkerAsync(mapImages);
+
+            done.WaitOne();
+        }
+    }
+}

--- a/Properties/AssemblyInfoCLI.cs
+++ b/Properties/AssemblyInfoCLI.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Voxel Fortress CLI")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Voxel Fortress CLI")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("33d3e3c7-dc9f-4f1e-8a13-31bfbd406f4a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Voxel Fortress CLI.csproj
+++ b/Voxel Fortress CLI.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Voxel_Fortress_CLI</RootNamespace>
+    <AssemblyName>Voxel_Fortress_CLI</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MapMaker.cs" />
+    <Compile Include="ProgramCLI.cs" />
+    <Compile Include="Properties\AssemblyInfoCLI.cs" />
+    <Compile Include="UniqueList.cs" />
+    <Compile Include="XRaw.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="AppCLI.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Voxel Fortress.sln
+++ b/Voxel Fortress.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Voxel Fortress", "Voxel Fortress.csproj", "{B8D139D6-1D2E-469A-8DFB-4525F105CE2B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Voxel Fortress CLI", "Voxel Fortress CLI.csproj", "{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{B8D139D6-1D2E-469A-8DFB-4525F105CE2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8D139D6-1D2E-469A-8DFB-4525F105CE2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8D139D6-1D2E-469A-8DFB-4525F105CE2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33D3E3C7-DC9F-4F1E-8A13-31BFBD406F4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This adds a rudimentary CLI, `Voxel_Fortress_CLI.exe`. My goal was to change no existing files (except the solution file), so this CLI could be better. In particular, this only uses `BackgroundWorker` from WPF because `MapMaker.LoadMap` requires it, and `PresentationFramework` because `XRaw` uses `MessageBox` (which belongs in the completion event handler).